### PR TITLE
dependency workflow must be pre-staged in main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: [Release, Leaked Secrets Scan]
+    types: [completed]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Install spacectl
+        uses: spacelift-io/setup-spacectl@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Notify Spacelift of deploy completion (success)
+        if: success()
+        env:
+          SPACELIFT_API_KEY_ENDPOINT: https://trufflesec.app.spacelift.io
+          SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+          SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+        run: spacectl run-external-dependency mark-completed --id "${GITHUB_SHA}-deploy" --status finished
+      - name: Notify Spacelift of deploy completion (failed)
+        if: failure()
+        env:
+          SPACELIFT_API_KEY_ENDPOINT: https://trufflesec.app.spacelift.io
+          SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+          SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+        run: spacectl run-external-dependency mark-completed --id "${GITHUB_SHA}-deploy" --status failed


### PR DESCRIPTION
Workflows using `workflow_run` events must be staged in default.

This should essentially "always" run, but only after either a Release, or a Leaked Secrets Scan.
