### PR TITLE
add success/fail checks to secret scan or release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  Deploy:
+  on-success:
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -26,17 +26,31 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Notify Spacelift of deploy completion (success)
-        if: success()
+      - name: Notify Spacelift of release or secret scan completion (success)
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         env:
           SPACELIFT_API_KEY_ENDPOINT: https://trufflesec.app.spacelift.io
           SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
           SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
-        run: spacectl run-external-dependency mark-completed --id "${GITHUB_SHA}-deploy" --status finished
-      - name: Notify Spacelift of deploy completion (failed)
-        if: failure()
+        run: spacectl run-external-dependency mark-completed --id "${GITHUB_SHA}-release-or-scan" --status finished
+
+  on-failure:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Install spacectl
+        uses: spacelift-io/setup-spacectl@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Notify Spacelift of release or secret scan completion (failed)
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         env:
           SPACELIFT_API_KEY_ENDPOINT: https://trufflesec.app.spacelift.io
           SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
           SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
-        run: spacectl run-external-dependency mark-completed --id "${GITHUB_SHA}-deploy" --status failed
+        run: spacectl run-external-dependency mark-completed --id "${GITHUB_SHA}-release-or-scan" --status failed


### PR DESCRIPTION
should not attempt a deploy if one of those steps failed