### PR TITLE
strips the gcs path uri prefix

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -27,7 +27,7 @@ func New(ctx context.Context, policyPath string, outputs []outputs.Output) (*eng
 	switch {
 	// GCS
 	case strings.HasPrefix(policyPath, "gs://"):
-		compiler, err = gcsCompiler(policyPath)
+		compiler, err = gcsCompiler(strings.TrimPrefix(policyPath, "gs://"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
avoids changing the engine